### PR TITLE
(chore): upgrade golangci-lint, fix errors with wsl_v5, consistent Go version

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -14,6 +14,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 USER vscode
 
 RUN go install -v github.com/cweill/gotests/gotests@v1.6.0 && \
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.1 && \
     go install golang.org/x/vuln/cmd/govulncheck@latest && \
     go install mvdan.cc/gofumpt@latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           version: latest
           args: --timeout=5m
+          problem-matchers: true
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
           cache: true
 
       - name: golangci-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: latest
-          args: --timeout=5m --out-format=colored-line-number
+          args: --timeout=5m
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
-          args: --timeout=5m
+          args: --timeout=5m --out-format=colored-line-number
 
   test:
     name: Test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,6 @@
 version: "2"
 run:
   timeout: 5m
-output:
-  format: colored-line-number
 linters:
   enable:
     - bodyclose

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,8 @@
 version: "2"
 run:
   timeout: 5m
+output:
+  format: colored-line-number
 linters:
   enable:
     - bodyclose

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,7 +12,12 @@ linters:
     - revive
     - staticcheck
     - whitespace
-    - wsl
+    - wsl_v5
+  settings:
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 4
   exclusions:
     generated: lax
     rules:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 # Install git and ca-certificates
 RUN apk add --no-cache git ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-coverage: ## Run tests with coverage
 lint: ## Run golangci-lint
 	@echo "Running golangci-lint..."
 	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run --timeout=5m; \
+		golangci-lint run --timeout=5m --out-format=colored-line-number; \
 	else \
 		echo "golangci-lint not found."; \
 		echo "Install with: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-coverage: ## Run tests with coverage
 lint: ## Run golangci-lint
 	@echo "Running golangci-lint..."
 	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run --timeout=5m --out-format=colored-line-number; \
+		golangci-lint run --timeout=5m; \
 	else \
 		echo "golangci-lint not found."; \
 		echo "Install with: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ docker-dev: ## Run with Docker in development mode
 		-e SLACK_BOT_TOKEN \
 		-e SLACK_SIGNING_SECRET \
 		-e NOTIFICATIONS_CHANNEL \
-		golang:1.22-alpine \
+		golang:1.24-alpine \
 		sh -c "apk add --no-cache git && go run main.go"
 
 fmt: ## Format code

--- a/incident/incident.go
+++ b/incident/incident.go
@@ -145,6 +145,7 @@ func isValidSeverity(s Severity) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -170,5 +171,6 @@ func GenerateIncidentID() string {
 		// Fallback to timestamp-based ID if random generation fails
 		return fmt.Sprintf("inc_%d", time.Now().UnixNano())
 	}
+
 	return fmt.Sprintf("inc_%x", bytes)
 }

--- a/incident/incident_test.go
+++ b/incident/incident_test.go
@@ -291,5 +291,6 @@ func containsSubstring(s, substr string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/timeline/timeline.go
+++ b/timeline/timeline.go
@@ -95,6 +95,7 @@ func (m *Manager) CreateTimeline(inc *incident.Incident, channelID string) (*Tim
 func (m *Manager) GetTimeline(incidentID string) (*Timeline, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
 	timeline, exists := m.timelines[incidentID]
 
 	if exists {
@@ -127,6 +128,7 @@ func (m *Manager) AddEntry(incidentID string, entry Entry) error {
 			"incident_id", incidentID,
 			"entry_type", entry.Type,
 			"user", entry.User)
+
 		return fmt.Errorf("timeline not found for incident: %s", incidentID)
 	}
 
@@ -149,6 +151,7 @@ func (m *Manager) AddEntry(incidentID string, entry Entry) error {
 			"error", err,
 			"incident_id", incidentID,
 			"entry_type", entry.Type)
+
 		return err
 	}
 
@@ -267,6 +270,7 @@ func (m *Manager) postTimelineToChannel(timeline *Timeline) error {
 	entries := make([]Entry, len(timeline.Entries))
 	copy(entries, timeline.Entries)
 	entriesCount := len(entries)
+
 	timeline.mu.RUnlock()
 
 	// Create timeline message
@@ -286,6 +290,7 @@ func (m *Manager) postTimelineToChannel(timeline *Timeline) error {
 			"incident_id", timeline.IncidentID,
 			"channel_id", timeline.ChannelID,
 			"message_length", messageLength)
+
 		return err
 	}
 
@@ -391,6 +396,7 @@ func (t *Timeline) GetEntries() []Entry {
 
 	entries := make([]Entry, len(t.Entries))
 	copy(entries, t.Entries)
+
 	return entries
 }
 


### PR DESCRIPTION
* Upgrade golangci-lint and install it in the devcontainer.
* Replace wsl linter with wsl_v5 and add settings for wsl_v5.
* Ensure the go version is consistent across CI and dev